### PR TITLE
Implementing OpenAPI Specification v3.1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python_version:
-          - "3.9"
-          - "3.10"
           - "3.11"
     runs-on: ${{ matrix.os }}
     continue-on-error: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ packaging==23.0
 pathspec==0.11.1
 platformdirs==3.2.0
 pluggy==1.0.0
+pyink==23.3.1
 pytest==7.3.0
 pytest-cov==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+black==23.3.0
+click==8.1.3
 coverage==7.2.3
 iniconfig==2.0.0
+mypy-extensions==1.0.0
 packaging==23.0
+pathspec==0.11.1
+platformdirs==3.2.0
 pluggy==1.0.0
 pytest==7.3.0
 pytest-cov==4.0.0
-yapf==0.32.0

--- a/tools/py/fmt.sh
+++ b/tools/py/fmt.sh
@@ -3,4 +3,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-yapf -i -r -p -vv --style=google --recur writableopenapi writableopenapitests
+python -m black -l 80 -t py311 --safe -v writableopenapi writableopenapitests

--- a/tools/py/fmt.sh
+++ b/tools/py/fmt.sh
@@ -3,4 +3,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-python -m black -l 80 -t py311 --safe -v writableopenapi writableopenapitests
+python -m pyink -l 80 -t py311 --safe -v writableopenapi writableopenapitests

--- a/tools/py/fmt_dry.sh
+++ b/tools/py/fmt_dry.sh
@@ -7,4 +7,4 @@
 # Dry run of yapf (does not write to files).
 # This is used in CI check for instance.
 
-python -m black -l 80 -t py311 --safe -v --diff --color writableopenapi writableopenapitests
+python -m pyink -l 80 -t py311 --safe -v --diff --color writableopenapi writableopenapitests

--- a/tools/py/fmt_dry.sh
+++ b/tools/py/fmt_dry.sh
@@ -7,4 +7,4 @@
 # Dry run of yapf (does not write to files).
 # This is used in CI check for instance.
 
-yapf -d -r -p -vv --style=google --recur writableopenapi writableopenapitests
+python -m black -l 80 -t py311 --safe -v --diff --color writableopenapi writableopenapitests

--- a/writableopenapi/openapi/__init__.py
+++ b/writableopenapi/openapi/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from callback import Callback
+from components import Components
+from contact import Contact
+from discriminator import Discriminator
+from encoding import Encoding
+from example import Example
+from external_documentation import ExternalDocumentation
+from header import Header
+from info import Info
+from license import License
+from link import Link
+from media_type import MediaType
+from oauth_flow import OAuthFlow
+from oauth_flows import OAuthFlows
+from openapi import OpenAPI
+from operation import Operation
+from parameter import Parameter
+from path_item import PathItem
+from paths import Paths
+from reference import Reference
+from request_body import RequestBody
+from response import Response
+from responses import Responses
+from schema import Schema
+from security_requirement import SecurityRequirement
+from security_scheme import SecurityScheme
+from server_variable import ServerVariable
+from server import Server
+from specification_extension import SpecificationExtension
+from tag import Tag
+from .xml import XML

--- a/writableopenapi/openapi/callback.py
+++ b/writableopenapi/openapi/callback.py
@@ -2,20 +2,20 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Union
 from specification_extension import SpecificationExtension
 from path_item import PathItem
+from reference import Reference
 
 
 @dataclass
 class Callback(SpecificationExtension):
-    pathItem: PathItem = PathItem()
+    paths: Dict[str, Union[Reference, PathItem]] = {}
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the callback into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data.update({k: v.dump() for k, v in self.paths.items()})
+
+        return data

--- a/writableopenapi/openapi/callback.py
+++ b/writableopenapi/openapi/callback.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict
+from specification_extension import SpecificationExtension
+from path_item import PathItem
+
+
+@dataclass
+class Callback(SpecificationExtension):
+    pathItem: PathItem = PathItem()
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the callback into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/components.py
+++ b/writableopenapi/openapi/components.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional, Union
+from specification_extension import SpecificationExtension
+from callback import Callback
+from example import Example
+from header import Header
+from link import Link
+from parameter import Parameter
+from reference import Reference
+from request_body import RequestBody
+from response import Response
+from schema import Schema
+from security_scheme import SecurityScheme
+
+
+@dataclass
+class Components(SpecificationExtension):
+    schemas: Optional[Dict[str, Union[Reference, Schema]]] = None
+    responses: Optional[Dict[str, Union[Reference, Response]]] = None
+    parameters: Optional[Dict[str, Union[Reference, Parameter]]] = None
+    examples: Optional[Dict[str, Union[Reference, Example]]] = None
+    requestBodies: Optional[Dict[str, Union[Reference, RequestBody]]] = None
+    headers: Optional[Dict[str, Union[Reference, Header]]] = None
+    securitySchemes: Optional[
+        Dict[str, Union[Reference, SecurityScheme]]
+    ] = None
+    links: Optional[Dict[str, Union[Reference, Link]]] = None
+    callbacks: Optional[Dict[str, Union[Reference, Callback]]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the components into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/components.py
+++ b/writableopenapi/openapi/components.py
@@ -23,9 +23,9 @@ class Components(SpecificationExtension):
     responses: Optional[Dict[str, Union[Reference, Response]]] = None
     parameters: Optional[Dict[str, Union[Reference, Parameter]]] = None
     examples: Optional[Dict[str, Union[Reference, Example]]] = None
-    requestBodies: Optional[Dict[str, Union[Reference, RequestBody]]] = None
+    request_bodies: Optional[Dict[str, Union[Reference, RequestBody]]] = None
     headers: Optional[Dict[str, Union[Reference, Header]]] = None
-    securitySchemes: Optional[
+    security_schemes: Optional[
         Dict[str, Union[Reference, SecurityScheme]]
     ] = None
     links: Optional[Dict[str, Union[Reference, Link]]] = None
@@ -44,15 +44,15 @@ class Components(SpecificationExtension):
             }
         if self.examples is not None:
             data["examples"] = {k: v.dump() for k, v in self.examples.items()}
-        if self.requestBodies is not None:
+        if self.request_bodies is not None:
             data["requestBodies"] = {
-                k: v.dump() for k, v in self.requestBodies.items()
+                k: v.dump() for k, v in self.request_bodies.items()
             }
         if self.headers is not None:
             data["headers"] = {k: v.dump() for k, v in self.headers.items()}
-        if self.securitySchemes is not None:
+        if self.security_schemes is not None:
             data["securitySchemes"] = {
-                k: v.dump() for k, v in self.securitySchemes.items()
+                k: v.dump() for k, v in self.security_schemes.items()
             }
         if self.links is not None:
             data["links"] = {k: v.dump() for k, v in self.links.items()}

--- a/writableopenapi/openapi/components.py
+++ b/writableopenapi/openapi/components.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 from specification_extension import SpecificationExtension
 from callback import Callback
@@ -33,8 +33,30 @@ class Components(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the components into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.schemas is not None:
+            data["schemas"] = {k: v.dump() for k, v in self.schemas.items()}
+        if self.responses is not None:
+            data["responses"] = {k: v.dump() for k, v in self.responses.items()}
+        if self.parameters is not None:
+            data["parameters"] = {
+                k: v.dump() for k, v in self.parameters.items()
+            }
+        if self.examples is not None:
+            data["examples"] = {k: v.dump() for k, v in self.examples.items()}
+        if self.requestBodies is not None:
+            data["requestBodies"] = {
+                k: v.dump() for k, v in self.requestBodies.items()
+            }
+        if self.headers is not None:
+            data["headers"] = {k: v.dump() for k, v in self.headers.items()}
+        if self.securitySchemes is not None:
+            data["securitySchemes"] = {
+                k: v.dump() for k, v in self.securitySchemes.items()
+            }
+        if self.links is not None:
+            data["links"] = {k: v.dump() for k, v in self.links.items()}
+        if self.callbacks is not None:
+            data["callbacks"] = {k: v.dump() for k, v in self.callbacks.items()}
+
+        return data

--- a/writableopenapi/openapi/contact.py
+++ b/writableopenapi/openapi/contact.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class Contact(SpecificationExtension):
+    name: Optional[str] = None
+    url: Optional[str] = None
+    email: Optional[str] = None
+
+    def dump(self) -> Dict[str, str]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/contact.py
+++ b/writableopenapi/openapi/contact.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -14,8 +14,12 @@ class Contact(SpecificationExtension):
     email: Optional[str] = None
 
     def dump(self) -> Dict[str, str]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.name is not None:
+            data["name"] = self.name
+        if self.url is not None:
+            data["url"] = self.url
+        if self.email is not None:
+            data["email"] = self.email
+
+        return data

--- a/writableopenapi/openapi/discriminator.py
+++ b/writableopenapi/openapi/discriminator.py
@@ -9,12 +9,12 @@ from specification_extension import SpecificationExtension
 
 @dataclass
 class Discriminator(SpecificationExtension):
-    propertyName: str = ""
+    property_name: str = ""
     mapping: Optional[Dict[str, str]] = None
 
     def dump(self) -> Dict[str, Any]:
         data = self.extensions
-        data["propertyName"] = self.propertyName
+        data["propertyName"] = self.property_name
         if self.mapping is not None:
             data["mapping"] = self.mapping
 

--- a/writableopenapi/openapi/discriminator.py
+++ b/writableopenapi/openapi/discriminator.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class Discriminator(SpecificationExtension):
+    propertyName: str = ""
+    mapping: Optional[Dict[str, str]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/discriminator.py
+++ b/writableopenapi/openapi/discriminator.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -13,8 +13,9 @@ class Discriminator(SpecificationExtension):
     mapping: Optional[Dict[str, str]] = None
 
     def dump(self) -> Dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["propertyName"] = self.propertyName
+        if self.mapping is not None:
+            data["mapping"] = self.mapping
+
+        return data

--- a/writableopenapi/openapi/encoding.py
+++ b/writableopenapi/openapi/encoding.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 from specification_extension import SpecificationExtension
 from header import Header
@@ -19,8 +19,16 @@ class Encoding(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the encoding into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.contentType is not None:
+            data["contentType"] = self.contentType
+        if self.headers is not None:
+            data["headers"] = {k: v.dump() for k, v in self.headers.items()}
+        if self.style is not None:
+            data["style"] = self.style
+        if self.explode is not None:
+            data["explode"] = self.explode
+        if self.allowReserved is not None:
+            data["allowReserved"] = self.allowReserved
+
+        return data

--- a/writableopenapi/openapi/encoding.py
+++ b/writableopenapi/openapi/encoding.py
@@ -11,24 +11,24 @@ from reference import Reference
 
 @dataclass
 class Encoding(SpecificationExtension):
-    contentType: Optional[str] = None
+    content_type: Optional[str] = None
     headers: Optional[Dict[str, Union[Reference, Header]]] = None
     style: Optional[str] = None
     explode: Optional[bool] = None
-    allowReserved: Optional[bool] = None
+    allow_reserved: Optional[bool] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the encoding into a dictionary."""
         data = self.extensions
-        if self.contentType is not None:
-            data["contentType"] = self.contentType
+        if self.content_type is not None:
+            data["contentType"] = self.content_type
         if self.headers is not None:
             data["headers"] = {k: v.dump() for k, v in self.headers.items()}
         if self.style is not None:
             data["style"] = self.style
         if self.explode is not None:
             data["explode"] = self.explode
-        if self.allowReserved is not None:
-            data["allowReserved"] = self.allowReserved
+        if self.allow_reserved is not None:
+            data["allowReserved"] = self.allow_reserved
 
         return data

--- a/writableopenapi/openapi/encoding.py
+++ b/writableopenapi/openapi/encoding.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional, Union
+from specification_extension import SpecificationExtension
+from header import Header
+from reference import Reference
+
+
+@dataclass
+class Encoding(SpecificationExtension):
+    contentType: Optional[str] = None
+    headers: Optional[Dict[str, Union[Reference, Header]]] = None
+    style: Optional[str] = None
+    explode: Optional[bool] = None
+    allowReserved: Optional[bool] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the encoding into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/example.py
+++ b/writableopenapi/openapi/example.py
@@ -22,7 +22,7 @@ class Example(SpecificationExtension):
         if self.description is not None:
             data["description"] = self.description
         if self.value is not None:
-            data["value"] = self.value.__str__()
+            data["value"] = str(self.value)
         if self.external_value is not None:
             data["externalValue"] = self.external_value
 

--- a/writableopenapi/openapi/example.py
+++ b/writableopenapi/openapi/example.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -16,8 +16,14 @@ class Example(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the example into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.summary is not None:
+            data["summary"] = self.summary
+        if self.description is not None:
+            data["description"] = self.description
+        if self.value is not None:
+            data["value"] = self.value.__str__()
+        if self.externalValue is not None:
+            data["externalValue"] = self.externalValue
+
+        return data

--- a/writableopenapi/openapi/example.py
+++ b/writableopenapi/openapi/example.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class Example(SpecificationExtension):
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    value: Optional[Any] = None
+    externalValue: Optional[str] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the example into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/example.py
+++ b/writableopenapi/openapi/example.py
@@ -12,7 +12,7 @@ class Example(SpecificationExtension):
     summary: Optional[str] = None
     description: Optional[str] = None
     value: Optional[Any] = None
-    externalValue: Optional[str] = None
+    external_value: Optional[str] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the example into a dictionary."""
@@ -23,7 +23,7 @@ class Example(SpecificationExtension):
             data["description"] = self.description
         if self.value is not None:
             data["value"] = self.value.__str__()
-        if self.externalValue is not None:
-            data["externalValue"] = self.externalValue
+        if self.external_value is not None:
+            data["externalValue"] = self.external_value
 
         return data

--- a/writableopenapi/openapi/external_documentation.py
+++ b/writableopenapi/openapi/external_documentation.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -13,8 +13,9 @@ class ExternalDocumentation(SpecificationExtension):
     url: str = ""
 
     def dump(self) -> Dict[str, str]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.description is not None:
+            data["description"] = self.description
+        data["url"] = self.url
+
+        return data

--- a/writableopenapi/openapi/external_documentation.py
+++ b/writableopenapi/openapi/external_documentation.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class ExternalDocumentation(SpecificationExtension):
+    description: Optional[str] = None
+    url: str = ""
+
+    def dump(self) -> Dict[str, str]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/header.py
+++ b/writableopenapi/openapi/header.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from schema import Schema
@@ -26,8 +26,28 @@ class Header(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the header into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.description is not None:
+            data["description"] = self.description
+        if self.required is not None:
+            data["required"] = self.required
+        if self.deprecated is not None:
+            data["deprecated"] = self.deprecated
+        if self.allowEmptyValue is not None:
+            data["allowEmptyValue"] = self.allowEmptyValue
+        if self.style is not None:
+            data["style"] = self.style
+        if self.explode is not None:
+            data["explode"] = self.explode
+        if self.allowReserved is not None:
+            data["allowReserved"] = self.allowReserved
+        if self.schema is not None:
+            data["schema"] = self.schema.dump()
+        if self.example is not None:
+            data["example"] = self.example.__str__()
+        if self.examples is not None:
+            data["examples"] = {k: v.dump() for k, v in self.examples.items()}
+        if self.content is not None:
+            data["content"] = {k: v.dump() for k, v in self.content.items()}
+
+        return data

--- a/writableopenapi/openapi/header.py
+++ b/writableopenapi/openapi/header.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from schema import Schema
+from example import Example
+from media_type import MediaType
+
+
+@dataclass
+class Header(SpecificationExtension):
+    description: Optional[str] = None
+    required: Optional[bool] = None
+    deprecated: Optional[bool] = None
+    allowEmptyValue: Optional[bool] = None
+    style: Optional[str] = None
+    explode: Optional[bool] = None
+    allowReserved: Optional[bool] = None
+    schema: Optional[Schema] = None
+    example: Optional[Any] = None
+    examples: Optional[Dict[str, Example]] = None
+    content: Optional[Dict[str, MediaType]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the header into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/header.py
+++ b/writableopenapi/openapi/header.py
@@ -15,10 +15,10 @@ class Header(SpecificationExtension):
     description: Optional[str] = None
     required: Optional[bool] = None
     deprecated: Optional[bool] = None
-    allowEmptyValue: Optional[bool] = None
+    allow_empty_value: Optional[bool] = None
     style: Optional[str] = None
     explode: Optional[bool] = None
-    allowReserved: Optional[bool] = None
+    allow_reserved: Optional[bool] = None
     schema: Optional[Schema] = None
     example: Optional[Any] = None
     examples: Optional[Dict[str, Example]] = None
@@ -33,14 +33,14 @@ class Header(SpecificationExtension):
             data["required"] = self.required
         if self.deprecated is not None:
             data["deprecated"] = self.deprecated
-        if self.allowEmptyValue is not None:
-            data["allowEmptyValue"] = self.allowEmptyValue
+        if self.allow_empty_value is not None:
+            data["allowEmptyValue"] = self.allow_empty_value
         if self.style is not None:
             data["style"] = self.style
         if self.explode is not None:
             data["explode"] = self.explode
-        if self.allowReserved is not None:
-            data["allowReserved"] = self.allowReserved
+        if self.allow_reserved is not None:
+            data["allowReserved"] = self.allow_reserved
         if self.schema is not None:
             data["schema"] = self.schema.dump()
         if self.example is not None:

--- a/writableopenapi/openapi/info.py
+++ b/writableopenapi/openapi/info.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Dict, Optional
+from specification_extension import SpecificationExtension
+from contact import Contact
+from license import License
+
+
+@dataclass
+class Info(SpecificationExtension):
+    title: str = ""
+    description: Optional[str] = None
+    termsOfService: Optional[str] = None
+    contact: Optional[Contact] = None
+    license: Optional[License] = None
+    version: str = ""
+
+    def dump(self) -> Dict[str, str]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/info.py
+++ b/writableopenapi/openapi/info.py
@@ -13,7 +13,7 @@ from license import License
 class Info(SpecificationExtension):
     title: str = ""
     description: Optional[str] = None
-    termsOfService: Optional[str] = None
+    terms_of_service: Optional[str] = None
     contact: Optional[Contact] = None
     license: Optional[License] = None
     version: str = ""
@@ -23,8 +23,8 @@ class Info(SpecificationExtension):
         data["title"] = self.title
         if self.description is not None:
             data["description"] = self.description
-        if self.termsOfService is not None:
-            data["termsOfService"] = self.termsOfService
+        if self.terms_of_service is not None:
+            data["termsOfService"] = self.terms_of_service
         if self.contact is not None:
             data["contact"] = self.contact.dump()
         if self.license is not None:

--- a/writableopenapi/openapi/info.py
+++ b/writableopenapi/openapi/info.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Dict, Optional
 from specification_extension import SpecificationExtension
 from contact import Contact
@@ -19,8 +19,16 @@ class Info(SpecificationExtension):
     version: str = ""
 
     def dump(self) -> Dict[str, str]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["title"] = self.title
+        if self.description is not None:
+            data["description"] = self.description
+        if self.termsOfService is not None:
+            data["termsOfService"] = self.termsOfService
+        if self.contact is not None:
+            data["contact"] = self.contact.dump()
+        if self.license is not None:
+            data["license"] = self.license.dump()
+        data["version"] = self.version
+
+        return data

--- a/writableopenapi/openapi/license.py
+++ b/writableopenapi/openapi/license.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class License(SpecificationExtension):
+    name: str = ""
+    url: Optional[str] = None
+    identifier: Optional[str] = None
+
+    def dump(self) -> Dict[str, str]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/license.py
+++ b/writableopenapi/openapi/license.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -14,8 +14,11 @@ class License(SpecificationExtension):
     identifier: Optional[str] = None
 
     def dump(self) -> Dict[str, str]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["name"] = self.name
+        if self.url is not None:
+            data["url"] = self.url
+        if self.identifier is not None:
+            data["identifier"] = self.identifier
+
+        return data

--- a/writableopenapi/openapi/link.py
+++ b/writableopenapi/openapi/link.py
@@ -10,24 +10,24 @@ from server import Server
 
 @dataclass
 class Link(SpecificationExtension):
-    operationRef: Optional[str] = None
-    operationId: Optional[str] = None
+    operation_ref: Optional[str] = None
+    operation_id: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
-    requestBody: Optional[Any] = None
+    request_body: Optional[Any] = None
     description: Optional[str] = None
     server: Optional[Server] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the link into a dictionary."""
         data = self.extensions
-        if self.operationRef is not None:
-            data["operationRef"] = self.operationRef
-        if self.operationId is not None:
-            data["operationId"] = self.operationId
+        if self.operation_ref is not None:
+            data["operationRef"] = self.operation_ref
+        if self.operation_id is not None:
+            data["operationId"] = self.operation_id
         if self.parameters is not None:
             data["parameters"] = self.parameters
-        if self.requestBody is not None:
-            data["requestBody"] = self.requestBody
+        if self.request_body is not None:
+            data["requestBody"] = self.request_body
         if self.description is not None:
             data["description"] = self.description
 

--- a/writableopenapi/openapi/link.py
+++ b/writableopenapi/openapi/link.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from server import Server
+
+
+@dataclass
+class Link(SpecificationExtension):
+    operationRef: Optional[str] = None
+    operationId: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    requestBody: Optional[Any] = None
+    description: Optional[str] = None
+    server: Optional[Server] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the link into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/link.py
+++ b/writableopenapi/openapi/link.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from server import Server
@@ -19,8 +19,16 @@ class Link(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the link into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.operationRef is not None:
+            data["operationRef"] = self.operationRef
+        if self.operationId is not None:
+            data["operationId"] = self.operationId
+        if self.parameters is not None:
+            data["parameters"] = self.parameters
+        if self.requestBody is not None:
+            data["requestBody"] = self.requestBody
+        if self.description is not None:
+            data["description"] = self.description
+
+        return data

--- a/writableopenapi/openapi/media_type.py
+++ b/writableopenapi/openapi/media_type.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 from specification_extension import SpecificationExtension
 from reference import Reference
@@ -20,8 +20,14 @@ class MediaType(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the media type into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.schema is not None:
+            data["schema"] = self.schema.dump()
+        if self.example is not None:
+            data["example"] = self.example.__str__()
+        if self.examples is not None:
+            data["examples"] = {k: v.dump() for k, v in self.examples.items()}
+        if self.encoding is not None:
+            data["encoding"] = {k: v.dump() for k, v in self.encoding.items()}
+
+        return data

--- a/writableopenapi/openapi/media_type.py
+++ b/writableopenapi/openapi/media_type.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional, Union
+from specification_extension import SpecificationExtension
+from reference import Reference
+from schema import Schema
+from example import Example
+from encoding import Encoding
+
+
+@dataclass
+class MediaType(SpecificationExtension):
+    schema: Optional[Union[Reference, Schema]] = None
+    example: Optional[Any] = None
+    examples: Optional[Dict[str, Union[Reference, Example]]] = None
+    encoding: Optional[Dict[str, Encoding]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the media type into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/oauth_flow.py
+++ b/writableopenapi/openapi/oauth_flow.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -16,8 +16,14 @@ class OAuthFlow(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OAuth flow into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.authorizationUrl is not None:
+            data["authorizationUrl"] = self.authorizationUrl
+        if self.tokenUrl is not None:
+            data["tokenUrl"] = self.tokenUrl
+        if self.refreshUrl is not None:
+            data["refreshUrl"] = self.refreshUrl
+        if self.scopes is not None:
+            data["scopes"] = self.scopes
+
+        return data

--- a/writableopenapi/openapi/oauth_flow.py
+++ b/writableopenapi/openapi/oauth_flow.py
@@ -9,20 +9,20 @@ from specification_extension import SpecificationExtension
 
 @dataclass
 class OAuthFlow(SpecificationExtension):
-    authorizationUrl: Optional[str] = None
-    tokenUrl: Optional[str] = None
-    refreshUrl: Optional[str] = None
+    authorization_url: Optional[str] = None
+    token_url: Optional[str] = None
+    refresh_url: Optional[str] = None
     scopes: Dict[str, str] = {}
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OAuth flow into a dictionary."""
         data = self.extensions
-        if self.authorizationUrl is not None:
-            data["authorizationUrl"] = self.authorizationUrl
-        if self.tokenUrl is not None:
-            data["tokenUrl"] = self.tokenUrl
-        if self.refreshUrl is not None:
-            data["refreshUrl"] = self.refreshUrl
+        if self.authorization_url is not None:
+            data["authorizationUrl"] = self.authorization_url
+        if self.token_url is not None:
+            data["tokenUrl"] = self.token_url
+        if self.refresh_url is not None:
+            data["refreshUrl"] = self.refresh_url
         if self.scopes is not None:
             data["scopes"] = self.scopes
 

--- a/writableopenapi/openapi/oauth_flow.py
+++ b/writableopenapi/openapi/oauth_flow.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class OAuthFlow(SpecificationExtension):
+    authorizationUrl: Optional[str] = None
+    tokenUrl: Optional[str] = None
+    refreshUrl: Optional[str] = None
+    scopes: Dict[str, str] = {}
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the OAuth flow into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/oauth_flows.py
+++ b/writableopenapi/openapi/oauth_flows.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from oauth_flow import OAuthFlow
+
+
+@dataclass
+class OAuthFlows(SpecificationExtension):
+    implicit: Optional[OAuthFlow] = None
+    password: Optional[OAuthFlow] = None
+    clientCredentials: Optional[OAuthFlow] = None
+    authorizationCode: Optional[OAuthFlow] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the OAuth flows into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/oauth_flows.py
+++ b/writableopenapi/openapi/oauth_flows.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from oauth_flow import OAuthFlow
@@ -17,8 +17,14 @@ class OAuthFlows(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OAuth flows into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.implicit is not None:
+            data["implicit"] = self.implicit.dump()
+        if self.password is not None:
+            data["password"] = self.password.dump()
+        if self.clientCredentials is not None:
+            data["clientCredentials"] = self.clientCredentials.dump()
+        if self.authorizationCode is not None:
+            data["authorizationCode"] = self.authorizationCode.dump()
+
+        return data

--- a/writableopenapi/openapi/oauth_flows.py
+++ b/writableopenapi/openapi/oauth_flows.py
@@ -12,8 +12,8 @@ from oauth_flow import OAuthFlow
 class OAuthFlows(SpecificationExtension):
     implicit: Optional[OAuthFlow] = None
     password: Optional[OAuthFlow] = None
-    clientCredentials: Optional[OAuthFlow] = None
-    authorizationCode: Optional[OAuthFlow] = None
+    client_credentials: Optional[OAuthFlow] = None
+    authorization_code: Optional[OAuthFlow] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OAuth flows into a dictionary."""
@@ -22,9 +22,9 @@ class OAuthFlows(SpecificationExtension):
             data["implicit"] = self.implicit.dump()
         if self.password is not None:
             data["password"] = self.password.dump()
-        if self.clientCredentials is not None:
-            data["clientCredentials"] = self.clientCredentials.dump()
-        if self.authorizationCode is not None:
-            data["authorizationCode"] = self.authorizationCode.dump()
+        if self.client_credentials is not None:
+            data["clientCredentials"] = self.client_credentials.dump()
+        if self.authorization_code is not None:
+            data["authorizationCode"] = self.authorization_code.dump()
 
         return data

--- a/writableopenapi/openapi/openapi.py
+++ b/writableopenapi/openapi/openapi.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from specification_extension import SpecificationExtension
 from components import Components
@@ -26,8 +26,21 @@ class OpenAPI(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OpenAPI specification into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
+        data = self.extensions
+        data["openapi"] = self.openapi
+        data["info"] = self.info.dump()
+        if self.servers is not None:
+            data["servers"] = [server.dump() for server in self.servers]
+        data["paths"] = {
+            path: path_item.dump() for path, path_item in self.paths.items()
         }
+        if self.components is not None:
+            data["components"] = self.components.dump()
+        if self.security is not None:
+            data["security"] = self.security
+        if self.tags is not None:
+            data["tags"] = [tag.dump() for tag in self.tags]
+        if self.externalDocs is not None:
+            data["externalDocs"] = self.externalDocs.dump()
+
+        return data

--- a/writableopenapi/openapi/openapi.py
+++ b/writableopenapi/openapi/openapi.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional
+from specification_extension import SpecificationExtension
+from components import Components
+from external_documentation import ExternalDocumentation
+from info import Info
+from path_item import PathItem
+from server import Server
+from tag import Tag
+
+
+@dataclass
+class OpenAPI(SpecificationExtension):
+    openapi: str = "3.0.0"
+    info: Info = Info()
+    servers: Optional[List[Server]] = None
+    paths: Dict[str, PathItem] = {}
+    components: Optional[Components] = None
+    security: Optional[List[Dict[str, List[str]]]] = None
+    tags: Optional[List[Tag]] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the OpenAPI specification into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/openapi.py
+++ b/writableopenapi/openapi/openapi.py
@@ -22,7 +22,7 @@ class OpenAPI(SpecificationExtension):
     components: Optional[Components] = None
     security: Optional[List[Dict[str, List[str]]]] = None
     tags: Optional[List[Tag]] = None
-    externalDocs: Optional[ExternalDocumentation] = None
+    external_docs: Optional[ExternalDocumentation] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the OpenAPI specification into a dictionary."""
@@ -40,7 +40,7 @@ class OpenAPI(SpecificationExtension):
             data["security"] = self.security
         if self.tags is not None:
             data["tags"] = [tag.dump() for tag in self.tags]
-        if self.externalDocs is not None:
-            data["externalDocs"] = self.externalDocs.dump()
+        if self.external_docs is not None:
+            data["externalDocs"] = self.external_docs.dump()
 
         return data

--- a/writableopenapi/openapi/operation.py
+++ b/writableopenapi/openapi/operation.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 from specification_extension import SpecificationExtension
 from callback import Callback
@@ -31,8 +31,37 @@ class Operation(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the operation into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
+        data = self.extensions
+        if self.tags is not None:
+            data["tags"] = self.tags
+        if self.summary is not None:
+            data["summary"] = self.summary
+        if self.description is not None:
+            data["description"] = self.description
+        if self.externalDocs is not None:
+            data["externalDocs"] = self.externalDocs.dump()
+        if self.operationId is not None:
+            data["operationId"] = self.operationId
+        if self.parameters is not None:
+            data["parameters"] = [
+                parameter.dump() for parameter in self.parameters
+            ]
+        if self.requestBody is not None:
+            data["requestBody"] = self.requestBody.dump()
+        data["responses"] = {
+            response: response.dump()
+            for response, response in self.responses.items()
         }
+        if self.callbacks is not None:
+            data["callbacks"] = {
+                callback: callback.dump()
+                for callback, callback in self.callbacks.items()
+            }
+        if self.deprecated is not None:
+            data["deprecated"] = self.deprecated
+        if self.security is not None:
+            data["security"] = self.security
+        if self.servers is not None:
+            data["servers"] = [server.dump() for server in self.servers]
+
+        return data

--- a/writableopenapi/openapi/operation.py
+++ b/writableopenapi/openapi/operation.py
@@ -19,10 +19,10 @@ class Operation(SpecificationExtension):
     tags: Optional[List[str]] = None
     summary: Optional[str] = None
     description: Optional[str] = None
-    externalDocs: Optional[ExternalDocumentation] = None
-    operationId: Optional[str] = None
+    external_docs: Optional[ExternalDocumentation] = None
+    operation_id: Optional[str] = None
     parameters: Optional[List[Union[Reference, Parameter]]] = None
-    requestBody: Optional[Union[Reference, RequestBody]] = None
+    request_body: Optional[Union[Reference, RequestBody]] = None
     responses: Dict[str, Union[Reference, Response]] = {}
     callbacks: Optional[Dict[str, Union[Reference, Callback]]] = None
     deprecated: Optional[bool] = None
@@ -38,16 +38,16 @@ class Operation(SpecificationExtension):
             data["summary"] = self.summary
         if self.description is not None:
             data["description"] = self.description
-        if self.externalDocs is not None:
-            data["externalDocs"] = self.externalDocs.dump()
-        if self.operationId is not None:
-            data["operationId"] = self.operationId
+        if self.external_docs is not None:
+            data["externalDocs"] = self.external_docs.dump()
+        if self.operation_id is not None:
+            data["operationId"] = self.operation_id
         if self.parameters is not None:
             data["parameters"] = [
                 parameter.dump() for parameter in self.parameters
             ]
-        if self.requestBody is not None:
-            data["requestBody"] = self.requestBody.dump()
+        if self.request_body is not None:
+            data["requestBody"] = self.request_body.dump()
         data["responses"] = {
             response: response.dump()
             for response, response in self.responses.items()

--- a/writableopenapi/openapi/operation.py
+++ b/writableopenapi/openapi/operation.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional, Union
+from specification_extension import SpecificationExtension
+from callback import Callback
+from external_documentation import ExternalDocumentation
+from parameter import Parameter
+from reference import Reference
+from request_body import RequestBody
+from response import Response
+from server import Server
+
+
+@dataclass
+class Operation(SpecificationExtension):
+    tags: Optional[List[str]] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+    operationId: Optional[str] = None
+    parameters: Optional[List[Union[Reference, Parameter]]] = None
+    requestBody: Optional[Union[Reference, RequestBody]] = None
+    responses: Dict[str, Union[Reference, Response]] = {}
+    callbacks: Optional[Dict[str, Union[Reference, Callback]]] = None
+    deprecated: Optional[bool] = None
+    security: Optional[List[Dict[str, List[str]]]] = None
+    servers: Optional[List[Server]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the operation into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/parameter.py
+++ b/writableopenapi/openapi/parameter.py
@@ -53,7 +53,7 @@ class Parameter(SpecificationExtension):
         if self.examples is not None:
             data["examples"] = {k: v.dump() for k, v in self.examples.items()}
         if self.example is not None:
-            data["example"] = self.example.__str__()
+            data["example"] = str(self.example)
         if self.content is not None:
             data["content"] = {k: v.dump() for k, v in self.content.items()}
 

--- a/writableopenapi/openapi/parameter.py
+++ b/writableopenapi/openapi/parameter.py
@@ -18,10 +18,10 @@ class Parameter(SpecificationExtension):
     description: Optional[str] = None
     required: Optional[bool] = None
     deprecated: Optional[bool] = None
-    allowEmptyValue: Optional[bool] = None
+    allow_empty_value: Optional[bool] = None
     style: Optional[str] = None
     explode: Optional[bool] = None
-    allowReserved: Optional[bool] = None
+    allow_reserved: Optional[bool] = None
     schema: Optional[Union[Reference, Schema]] = None
     examples: Optional[Dict[str, Union[Reference, Example]]] = None
     example: Optional[Any] = None
@@ -40,14 +40,14 @@ class Parameter(SpecificationExtension):
             data["required"] = self.required
         if self.deprecated is not None:
             data["deprecated"] = self.deprecated
-        if self.allowEmptyValue is not None:
-            data["allowEmptyValue"] = self.allowEmptyValue
+        if self.allow_empty_value is not None:
+            data["allowEmptyValue"] = self.allow_empty_value
         if self.style is not None:
             data["style"] = self.style
         if self.explode is not None:
             data["explode"] = self.explode
-        if self.allowReserved is not None:
-            data["allowReserved"] = self.allowReserved
+        if self.allow_reserved is not None:
+            data["allowReserved"] = self.allow_reserved
         if self.schema is not None:
             data["schema"] = self.schema.dump()
         if self.examples is not None:

--- a/writableopenapi/openapi/parameter.py
+++ b/writableopenapi/openapi/parameter.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional, Union
+from specification_extension import SpecificationExtension
+from example import Example
+from reference import Reference
+from schema import Schema
+from media_type import MediaType
+
+
+@dataclass
+class Parameter(SpecificationExtension):
+    name: str = ""
+    in_: str = ""
+    description: Optional[str] = None
+    required: Optional[bool] = None
+    deprecated: Optional[bool] = None
+    allowEmptyValue: Optional[bool] = None
+    style: Optional[str] = None
+    explode: Optional[bool] = None
+    allowReserved: Optional[bool] = None
+    schema: Optional[Union[Reference, Schema]] = None
+    examples: Optional[Dict[str, Union[Reference, Example]]] = None
+    example: Optional[Any] = None
+    content: Optional[Dict[str, MediaType]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the parameter into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/parameter.py
+++ b/writableopenapi/openapi/parameter.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 from specification_extension import SpecificationExtension
 from example import Example
@@ -29,8 +29,32 @@ class Parameter(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the parameter into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.name is not None:
+            data["name"] = self.name
+        if self.in_ is not None:
+            data["in"] = self.in_
+        if self.description is not None:
+            data["description"] = self.description
+        if self.required is not None:
+            data["required"] = self.required
+        if self.deprecated is not None:
+            data["deprecated"] = self.deprecated
+        if self.allowEmptyValue is not None:
+            data["allowEmptyValue"] = self.allowEmptyValue
+        if self.style is not None:
+            data["style"] = self.style
+        if self.explode is not None:
+            data["explode"] = self.explode
+        if self.allowReserved is not None:
+            data["allowReserved"] = self.allowReserved
+        if self.schema is not None:
+            data["schema"] = self.schema.dump()
+        if self.examples is not None:
+            data["examples"] = {k: v.dump() for k, v in self.examples.items()}
+        if self.example is not None:
+            data["example"] = self.example.__str__()
+        if self.content is not None:
+            data["content"] = {k: v.dump() for k, v in self.content.items()}
+
+        return data

--- a/writableopenapi/openapi/path_item.py
+++ b/writableopenapi/openapi/path_item.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 from specification_extension import SpecificationExtension
 from operation import Operation
@@ -28,8 +28,32 @@ class PathItem(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the path item into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.summary is not None:
+            data["summary"] = self.summary
+        if self.description is not None:
+            data["description"] = self.description
+        if self.get is not None:
+            data["get"] = self.get.dump()
+        if self.put is not None:
+            data["put"] = self.put.dump()
+        if self.post is not None:
+            data["post"] = self.post.dump()
+        if self.delete is not None:
+            data["delete"] = self.delete.dump()
+        if self.options is not None:
+            data["options"] = self.options.dump()
+        if self.head is not None:
+            data["head"] = self.head.dump()
+        if self.patch is not None:
+            data["patch"] = self.patch.dump()
+        if self.trace is not None:
+            data["trace"] = self.trace.dump()
+        if self.servers is not None:
+            data["servers"] = [server.dump() for server in self.servers]
+        if self.parameters is not None:
+            data["parameters"] = [
+                parameter.dump() for parameter in self.parameters
+            ]
+
+        return data

--- a/writableopenapi/openapi/path_item.py
+++ b/writableopenapi/openapi/path_item.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional, Union
+from specification_extension import SpecificationExtension
+from operation import Operation
+from server import Server
+from reference import Reference
+from parameter import Parameter
+
+
+@dataclass
+class PathItem(SpecificationExtension):
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    get: Optional[Operation] = None
+    put: Optional[Operation] = None
+    post: Optional[Operation] = None
+    delete: Optional[Operation] = None
+    options: Optional[Operation] = None
+    head: Optional[Operation] = None
+    patch: Optional[Operation] = None
+    trace: Optional[Operation] = None
+    servers: Optional[List[Server]] = None
+    parameters: Optional[List[Union[Reference, Parameter]]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the path item into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/paths.py
+++ b/writableopenapi/openapi/paths.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict
 from specification_extension import SpecificationExtension
 from path_item import PathItem
@@ -14,8 +14,6 @@ class Paths(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the paths into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data.update({k: v.dump() for k, v in self.paths.items()})
+        return data

--- a/writableopenapi/openapi/paths.py
+++ b/writableopenapi/openapi/paths.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict
+from specification_extension import SpecificationExtension
+from path_item import PathItem
+
+
+@dataclass
+class Paths(SpecificationExtension):
+    paths: Dict[str, PathItem] = {}
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the paths into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/reference.py
+++ b/writableopenapi/openapi/reference.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass
+from typing import Dict
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class Reference(SpecificationExtension):
+    ref: str = ""
+
+    def dump(self) -> Dict[str, str]:
+        return {"$ref": self.ref}

--- a/writableopenapi/openapi/reference.py
+++ b/writableopenapi/openapi/reference.py
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Any
 from specification_extension import SpecificationExtension
 
 
@@ -11,5 +11,8 @@ from specification_extension import SpecificationExtension
 class Reference(SpecificationExtension):
     ref: str = ""
 
-    def dump(self) -> Dict[str, str]:
-        return {"$ref": self.ref}
+    def dump(self) -> Dict[str, Any]:
+        data = self.extensions
+        data["$ref"] = self.ref
+
+        return data

--- a/writableopenapi/openapi/request_body.py
+++ b/writableopenapi/openapi/request_body.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from media_type import MediaType
+
+
+@dataclass
+class RequestBody(SpecificationExtension):
+    description: Optional[str] = None
+    content: Dict[str, MediaType] = {}
+    required: Optional[bool] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the request body into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/request_body.py
+++ b/writableopenapi/openapi/request_body.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from media_type import MediaType
@@ -16,8 +16,12 @@ class RequestBody(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the request body into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.description is not None:
+            data["description"] = self.description
+        if self.content is not None:
+            data["content"] = {k: v.dump() for k, v in self.content.items()}
+        if self.required is not None:
+            data["required"] = self.required
+
+        return data

--- a/writableopenapi/openapi/response.py
+++ b/writableopenapi/openapi/response.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional, Union
+from specification_extension import SpecificationExtension
+from header import Header
+from link import Link
+from media_type import MediaType
+from reference import Reference
+
+
+@dataclass
+class Response(SpecificationExtension):
+    description: str = ""
+    headers: Optional[Dict[str, Union[Reference, Header]]] = None
+    content: Optional[Dict[str, MediaType]] = None
+    links: Optional[Dict[str, Union[Reference, Link]]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the response into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/response.py
+++ b/writableopenapi/openapi/response.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 from specification_extension import SpecificationExtension
 from header import Header
@@ -20,8 +20,12 @@ class Response(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the response into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["description"] = self.description
+        if self.headers is not None:
+            data["headers"] = {k: v.dump() for k, v in self.headers.items()}
+        if self.content is not None:
+            data["content"] = {k: v.dump() for k, v in self.content.items()}
+        if self.links is not None:
+            data["links"] = {k: v.dump() for k, v in self.links.items()}
+        return data

--- a/writableopenapi/openapi/responses.py
+++ b/writableopenapi/openapi/responses.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Union
+from specification_extension import SpecificationExtension
+from reference import Reference
+from response import Response
+
+
+@dataclass
+class Responses(SpecificationExtension):
+    responses: Dict[str, Union[Reference, Response]] = {}
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the responses into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/responses.py
+++ b/writableopenapi/openapi/responses.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Union
 from specification_extension import SpecificationExtension
 from reference import Reference
@@ -15,8 +15,6 @@ class Responses(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the responses into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["responses"] = {k: v.dump() for k, v in self.responses.items()}
+        return data

--- a/writableopenapi/openapi/schema.py
+++ b/writableopenapi/openapi/schema.py
@@ -14,40 +14,40 @@ from external_documentation import ExternalDocumentation
 @dataclass
 class Schema(SpecificationExtension):
     title: Optional[str] = None
-    multipleOf: Optional[float] = None
+    multiple_of: Optional[float] = None
     maximum: Optional[float] = None
-    exclusiveMaximum: Optional[float] = None
+    exclusive_maximum: Optional[float] = None
     minimum: Optional[float] = None
-    exclusiveMinimum: Optional[float] = None
-    maxLength: Optional[int] = None
-    minLength: Optional[int] = None
+    exclusive_minimum: Optional[float] = None
+    max_length: Optional[int] = None
+    min_length: Optional[int] = None
     pattern: Optional[str] = None
-    maxItems: Optional[int] = None
-    minItems: Optional[int] = None
-    uniqueItems: Optional[bool] = None
-    maxProperties: Optional[int] = None
-    minProperties: Optional[int] = None
+    max_items: Optional[int] = None
+    min_items: Optional[int] = None
+    unique_items: Optional[bool] = None
+    max_properties: Optional[int] = None
+    min_properties: Optional[int] = None
     required: Optional[List[str]] = None
     enum: Optional[List[Any]] = None
     type: Optional[Union[str, List[str]]] = None
-    allOf: Optional[List[Union[Reference, "Schema"]]] = None
-    oneOf: Optional[List[Union[Reference, "Schema"]]] = None
-    anyOf: Optional[List[Union[Reference, "Schema"]]] = None
+    all_of: Optional[List[Union[Reference, "Schema"]]] = None
+    one_of: Optional[List[Union[Reference, "Schema"]]] = None
+    any_of: Optional[List[Union[Reference, "Schema"]]] = None
     not_: Optional[Union[Reference, "Schema"]] = None
     items: Optional[
         Union[Reference, "Schema", List[Union[Reference, "Schema"]]]
     ] = None
     properties: Optional[Dict[str, Union[Reference, "Schema"]]] = None
-    additionalProperties: Optional[Union[bool, Reference, "Schema"]] = None
+    additional_properties: Optional[Union[bool, Reference, "Schema"]] = None
     description: Optional[str] = None
     format: Optional[str] = None
     default: Optional[Any] = None
     nullable: Optional[bool] = None
     discriminator: Optional[Discriminator] = None
-    readOnly: Optional[bool] = None
-    writeOnly: Optional[bool] = None
+    read_only: Optional[bool] = None
+    write_only: Optional[bool] = None
     xml: Optional[XML] = None
-    externalDocs: Optional[ExternalDocumentation] = None
+    external_docs: Optional[ExternalDocumentation] = None
     example: Optional[Any] = None
     deprecated: Optional[bool] = None
 
@@ -56,44 +56,44 @@ class Schema(SpecificationExtension):
         data = self.extensions
         if self.title is not None:
             data["title"] = self.title
-        if self.multipleOf is not None:
-            data["multipleOf"] = self.multipleOf
+        if self.multiple_of is not None:
+            data["multipleOf"] = self.multiple_of
         if self.maximum is not None:
             data["maximum"] = self.maximum
-        if self.exclusiveMaximum is not None:
-            data["exclusiveMaximum"] = self.exclusiveMaximum
+        if self.exclusive_maximum is not None:
+            data["exclusiveMaximum"] = self.exclusive_maximum
         if self.minimum is not None:
             data["minimum"] = self.minimum
-        if self.exclusiveMinimum is not None:
-            data["exclusiveMinimum"] = self.exclusiveMinimum
-        if self.maxLength is not None:
-            data["maxLength"] = self.maxLength
-        if self.minLength is not None:
-            data["minLength"] = self.minLength
+        if self.exclusive_minimum is not None:
+            data["exclusiveMinimum"] = self.exclusive_minimum
+        if self.max_length is not None:
+            data["maxLength"] = self.max_length
+        if self.min_length is not None:
+            data["minLength"] = self.min_length
         if self.pattern is not None:
             data["pattern"] = self.pattern
-        if self.maxItems is not None:
-            data["maxItems"] = self.maxItems
-        if self.minItems is not None:
-            data["minItems"] = self.minItems
-        if self.uniqueItems is not None:
-            data["uniqueItems"] = self.uniqueItems
-        if self.maxProperties is not None:
-            data["maxProperties"] = self.maxProperties
-        if self.minProperties is not None:
-            data["minProperties"] = self.minProperties
+        if self.max_items is not None:
+            data["maxItems"] = self.max_items
+        if self.min_items is not None:
+            data["minItems"] = self.min_items
+        if self.unique_items is not None:
+            data["uniqueItems"] = self.unique_items
+        if self.max_properties is not None:
+            data["maxProperties"] = self.max_properties
+        if self.min_properties is not None:
+            data["minProperties"] = self.min_properties
         if self.required is not None:
             data["required"] = self.required
         if self.enum is not None:
             data["enum"] = self.enum
         if self.type is not None:
             data["type"] = self.type
-        if self.allOf is not None:
-            data["allOf"] = [v.dump() for v in self.allOf]
-        if self.oneOf is not None:
-            data["oneOf"] = [v.dump() for v in self.oneOf]
-        if self.anyOf is not None:
-            data["anyOf"] = [v.dump() for v in self.anyOf]
+        if self.all_of is not None:
+            data["allOf"] = [v.dump() for v in self.all_of]
+        if self.one_of is not None:
+            data["oneOf"] = [v.dump() for v in self.one_of]
+        if self.any_of is not None:
+            data["anyOf"] = [v.dump() for v in self.any_of]
         if self.not_ is not None:
             data["not"] = self.not_.dump()
         if self.items is not None:
@@ -105,11 +105,11 @@ class Schema(SpecificationExtension):
             data["properties"] = {
                 k: v.dump() for k, v in self.properties.items()
             }
-        if self.additionalProperties is not None:
-            if isinstance(self.additionalProperties, bool):
-                data["additionalProperties"] = self.additionalProperties
+        if self.additional_properties is not None:
+            if isinstance(self.additional_properties, bool):
+                data["additionalProperties"] = self.additional_properties
             else:
-                data["additionalProperties"] = self.additionalProperties.dump()
+                data["additionalProperties"] = self.additional_properties.dump()
         if self.description is not None:
             data["description"] = self.description
         if self.format is not None:
@@ -120,14 +120,14 @@ class Schema(SpecificationExtension):
             data["nullable"] = self.nullable
         if self.discriminator is not None:
             data["discriminator"] = self.discriminator.dump()
-        if self.readOnly is not None:
-            data["readOnly"] = self.readOnly
-        if self.writeOnly is not None:
-            data["writeOnly"] = self.writeOnly
+        if self.read_only is not None:
+            data["readOnly"] = self.read_only
+        if self.write_only is not None:
+            data["writeOnly"] = self.write_only
         if self.xml is not None:
             data["xml"] = self.xml.dump()
-        if self.externalDocs is not None:
-            data["externalDocs"] = self.externalDocs.dump()
+        if self.external_docs is not None:
+            data["externalDocs"] = self.external_docs.dump()
         if self.example is not None:
             data["example"] = self.example
         if self.deprecated is not None:

--- a/writableopenapi/openapi/schema.py
+++ b/writableopenapi/openapi/schema.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional, Union
+from specification_extension import SpecificationExtension
+from reference import Reference
+from discriminator import Discriminator
+from .xml import XML
+from external_documentation import ExternalDocumentation
+
+
+@dataclass
+class Schema(SpecificationExtension):
+    title: Optional[str] = None
+    multipleOf: Optional[float] = None
+    maximum: Optional[float] = None
+    exclusiveMaximum: Optional[float] = None
+    minimum: Optional[float] = None
+    exclusiveMinimum: Optional[float] = None
+    maxLength: Optional[int] = None
+    minLength: Optional[int] = None
+    pattern: Optional[str] = None
+    maxItems: Optional[int] = None
+    minItems: Optional[int] = None
+    uniqueItems: Optional[bool] = None
+    maxProperties: Optional[int] = None
+    minProperties: Optional[int] = None
+    required: Optional[List[str]] = None
+    enum: Optional[List[Any]] = None
+    type: Optional[Union[str, List[str]]] = None
+    allOf: Optional[List[Union[Reference, "Schema"]]] = None
+    oneOf: Optional[List[Union[Reference, "Schema"]]] = None
+    anyOf: Optional[List[Union[Reference, "Schema"]]] = None
+    not_: Optional[Union[Reference, "Schema"]] = None
+    items: Optional[
+        Union[Reference, "Schema", List[Union[Reference, "Schema"]]]
+    ] = None
+    properties: Optional[Dict[str, Union[Reference, "Schema"]]] = None
+    additionalProperties: Optional[Union[bool, Reference, "Schema"]] = None
+    description: Optional[str] = None
+    format: Optional[str] = None
+    default: Optional[Any] = None
+    nullable: Optional[bool] = None
+    discriminator: Optional[Discriminator] = None
+    readOnly: Optional[bool] = None
+    writeOnly: Optional[bool] = None
+    xml: Optional[XML] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+    example: Optional[Any] = None
+    deprecated: Optional[bool] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the schema into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/schema.py
+++ b/writableopenapi/openapi/schema.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 from specification_extension import SpecificationExtension
 from reference import Reference
@@ -53,8 +53,83 @@ class Schema(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the schema into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.title is not None:
+            data["title"] = self.title
+        if self.multipleOf is not None:
+            data["multipleOf"] = self.multipleOf
+        if self.maximum is not None:
+            data["maximum"] = self.maximum
+        if self.exclusiveMaximum is not None:
+            data["exclusiveMaximum"] = self.exclusiveMaximum
+        if self.minimum is not None:
+            data["minimum"] = self.minimum
+        if self.exclusiveMinimum is not None:
+            data["exclusiveMinimum"] = self.exclusiveMinimum
+        if self.maxLength is not None:
+            data["maxLength"] = self.maxLength
+        if self.minLength is not None:
+            data["minLength"] = self.minLength
+        if self.pattern is not None:
+            data["pattern"] = self.pattern
+        if self.maxItems is not None:
+            data["maxItems"] = self.maxItems
+        if self.minItems is not None:
+            data["minItems"] = self.minItems
+        if self.uniqueItems is not None:
+            data["uniqueItems"] = self.uniqueItems
+        if self.maxProperties is not None:
+            data["maxProperties"] = self.maxProperties
+        if self.minProperties is not None:
+            data["minProperties"] = self.minProperties
+        if self.required is not None:
+            data["required"] = self.required
+        if self.enum is not None:
+            data["enum"] = self.enum
+        if self.type is not None:
+            data["type"] = self.type
+        if self.allOf is not None:
+            data["allOf"] = [v.dump() for v in self.allOf]
+        if self.oneOf is not None:
+            data["oneOf"] = [v.dump() for v in self.oneOf]
+        if self.anyOf is not None:
+            data["anyOf"] = [v.dump() for v in self.anyOf]
+        if self.not_ is not None:
+            data["not"] = self.not_.dump()
+        if self.items is not None:
+            if isinstance(self.items, list):
+                data["items"] = [v.dump() for v in self.items]
+            else:
+                data["items"] = self.items.dump()
+        if self.properties is not None:
+            data["properties"] = {
+                k: v.dump() for k, v in self.properties.items()
+            }
+        if self.additionalProperties is not None:
+            if isinstance(self.additionalProperties, bool):
+                data["additionalProperties"] = self.additionalProperties
+            else:
+                data["additionalProperties"] = self.additionalProperties.dump()
+        if self.description is not None:
+            data["description"] = self.description
+        if self.format is not None:
+            data["format"] = self.format
+        if self.default is not None:
+            data["default"] = self.default
+        if self.nullable is not None:
+            data["nullable"] = self.nullable
+        if self.discriminator is not None:
+            data["discriminator"] = self.discriminator.dump()
+        if self.readOnly is not None:
+            data["readOnly"] = self.readOnly
+        if self.writeOnly is not None:
+            data["writeOnly"] = self.writeOnly
+        if self.xml is not None:
+            data["xml"] = self.xml.dump()
+        if self.externalDocs is not None:
+            data["externalDocs"] = self.externalDocs.dump()
+        if self.example is not None:
+            data["example"] = self.example
+        if self.deprecated is not None:
+            data["deprecated"] = self.deprecated
+        return data

--- a/writableopenapi/openapi/security_requirement.py
+++ b/writableopenapi/openapi/security_requirement.py
@@ -9,11 +9,11 @@ from specification_extension import SpecificationExtension
 
 @dataclass
 class SecurityRequirement(SpecificationExtension):
-    securityRequirement: Dict[str, List[str]] = {}
+    security_requirement: Dict[str, List[str]] = {}
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the security requirement into a dictionary."""
         data = self.extensions
-        data.update(self.securityRequirement)
+        data.update(self.security_requirement)
 
         return data

--- a/writableopenapi/openapi/security_requirement.py
+++ b/writableopenapi/openapi/security_requirement.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List
 from specification_extension import SpecificationExtension
 
@@ -13,8 +13,7 @@ class SecurityRequirement(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the security requirement into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data.update(self.securityRequirement)
+
+        return data

--- a/writableopenapi/openapi/security_requirement.py
+++ b/writableopenapi/openapi/security_requirement.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class SecurityRequirement(SpecificationExtension):
+    securityRequirement: Dict[str, List[str]] = {}
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the security requirement into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/security_scheme.py
+++ b/writableopenapi/openapi/security_scheme.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from oauth_flows import OAuthFlows
+
+
+@dataclass
+class SecurityScheme(SpecificationExtension):
+    type: str = ""
+    description: Optional[str] = None
+    name: Optional[str] = None
+    in_: Optional[str] = None
+    scheme: Optional[str] = None
+    bearerFormat: Optional[str] = None
+    flows: Optional[OAuthFlows] = None
+    openIdConnectUrl: Optional[str] = None
+
+    def dump(self) -> Dict[str, Any]:
+        """Dumps the security scheme into a dictionary."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/security_scheme.py
+++ b/writableopenapi/openapi/security_scheme.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from oauth_flows import OAuthFlows
@@ -21,8 +21,21 @@ class SecurityScheme(SpecificationExtension):
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the security scheme into a dictionary."""
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["type"] = self.type
+        if self.description is not None:
+            data["description"] = self.description
+        if self.name is not None:
+            data["name"] = self.name
+        if self.in_ is not None:
+            data["in"] = self.in_
+        if self.scheme is not None:
+            data["scheme"] = self.scheme
+        if self.bearerFormat is not None:
+            data["bearerFormat"] = self.bearerFormat
+        if self.flows is not None:
+            data["flows"] = self.flows.dump()
+        if self.openIdConnectUrl is not None:
+            data["openIdConnectUrl"] = self.openIdConnectUrl
+
+        return data

--- a/writableopenapi/openapi/security_scheme.py
+++ b/writableopenapi/openapi/security_scheme.py
@@ -15,9 +15,9 @@ class SecurityScheme(SpecificationExtension):
     name: Optional[str] = None
     in_: Optional[str] = None
     scheme: Optional[str] = None
-    bearerFormat: Optional[str] = None
+    bearer_format: Optional[str] = None
     flows: Optional[OAuthFlows] = None
-    openIdConnectUrl: Optional[str] = None
+    open_id_connect_url: Optional[str] = None
 
     def dump(self) -> Dict[str, Any]:
         """Dumps the security scheme into a dictionary."""
@@ -31,11 +31,11 @@ class SecurityScheme(SpecificationExtension):
             data["in"] = self.in_
         if self.scheme is not None:
             data["scheme"] = self.scheme
-        if self.bearerFormat is not None:
-            data["bearerFormat"] = self.bearerFormat
+        if self.bearer_format is not None:
+            data["bearerFormat"] = self.bearer_format
         if self.flows is not None:
             data["flows"] = self.flows.dump()
-        if self.openIdConnectUrl is not None:
-            data["openIdConnectUrl"] = self.openIdConnectUrl
+        if self.open_id_connect_url is not None:
+            data["openIdConnectUrl"] = self.open_id_connect_url
 
         return data

--- a/writableopenapi/openapi/server.py
+++ b/writableopenapi/openapi/server.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from server_variable import ServerVariable
+
+
+@dataclass
+class Server(SpecificationExtension):
+    url: str = ""
+    description: Optional[str] = None
+    variables: Optional[Dict[str, ServerVariable]] = None
+
+    def dump(self) -> Dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/server.py
+++ b/writableopenapi/openapi/server.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from server_variable import ServerVariable
@@ -15,8 +15,11 @@ class Server(SpecificationExtension):
     variables: Optional[Dict[str, ServerVariable]] = None
 
     def dump(self) -> Dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["url"] = self.url
+        if self.description is not None:
+            data["description"] = self.description
+        if self.variables is not None:
+            data["variables"] = {k: v.dump() for k, v in self.variables.items()}
+
+        return data

--- a/writableopenapi/openapi/server_variable.py
+++ b/writableopenapi/openapi/server_variable.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from specification_extension import SpecificationExtension
 
@@ -14,8 +14,11 @@ class ServerVariable(SpecificationExtension):
     description: Optional[str] = None
 
     def dump(self) -> Dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.enum is not None:
+            data["enum"] = self.enum
+        data["default"] = self.default
+        if self.description is not None:
+            data["description"] = self.description
+
+        return data

--- a/writableopenapi/openapi/server_variable.py
+++ b/writableopenapi/openapi/server_variable.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class ServerVariable(SpecificationExtension):
+    enum: Optional[List[str]] = None
+    default: str = ""
+    description: Optional[str] = None
+
+    def dump(self) -> Dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/specification_extension.py
+++ b/writableopenapi/openapi/specification_extension.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class SpecificationExtension:
+    extensions: Dict[str, Any] = {}
+    """Additional properties, names should be prefixed with `x-`."""
+
+    def dump(self) -> Dict[str, Any]:
+        return self.extensions

--- a/writableopenapi/openapi/tag.py
+++ b/writableopenapi/openapi/tag.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 from external_documentation import ExternalDocumentation
@@ -15,8 +15,11 @@ class Tag(SpecificationExtension):
     externalDocs: Optional[ExternalDocumentation] = None
 
     def dump(self) -> Dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        data["name"] = self.name
+        if self.description is not None:
+            data["description"] = self.description
+        if self.externalDocs is not None:
+            data["externalDocs"] = self.externalDocs.dump()
+
+        return data

--- a/writableopenapi/openapi/tag.py
+++ b/writableopenapi/openapi/tag.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+from external_documentation import ExternalDocumentation
+
+
+@dataclass
+class Tag(SpecificationExtension):
+    name: str = ""
+    description: Optional[str] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+
+    def dump(self) -> Dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/tag.py
+++ b/writableopenapi/openapi/tag.py
@@ -12,14 +12,14 @@ from external_documentation import ExternalDocumentation
 class Tag(SpecificationExtension):
     name: str = ""
     description: Optional[str] = None
-    externalDocs: Optional[ExternalDocumentation] = None
+    external_docs: Optional[ExternalDocumentation] = None
 
     def dump(self) -> Dict[str, Any]:
         data = self.extensions
         data["name"] = self.name
         if self.description is not None:
             data["description"] = self.description
-        if self.externalDocs is not None:
-            data["externalDocs"] = self.externalDocs.dump()
+        if self.external_docs is not None:
+            data["externalDocs"] = self.external_docs.dump()
 
         return data

--- a/writableopenapi/openapi/xml.py
+++ b/writableopenapi/openapi/xml.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Nicolas Paul All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Optional
+from specification_extension import SpecificationExtension
+
+
+@dataclass
+class XML(SpecificationExtension):
+    name: Optional[str] = None
+    namespace: Optional[str] = None
+    prefix: Optional[str] = None
+    attribute: Optional[bool] = None
+    wrapped: Optional[bool] = None
+
+    def dump(self) -> Dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }

--- a/writableopenapi/openapi/xml.py
+++ b/writableopenapi/openapi/xml.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from specification_extension import SpecificationExtension
 
@@ -16,8 +16,16 @@ class XML(SpecificationExtension):
     wrapped: Optional[bool] = None
 
     def dump(self) -> Dict[str, Any]:
-        return {
-            field.name: getattr(self, field.name)
-            for field in fields(self)
-            if getattr(self, field.name) is not None
-        }
+        data = self.extensions
+        if self.name is not None:
+            data["name"] = self.name
+        if self.namespace is not None:
+            data["namespace"] = self.namespace
+        if self.prefix is not None:
+            data["prefix"] = self.prefix
+        if self.attribute is not None:
+            data["attribute"] = self.attribute
+        if self.wrapped is not None:
+            data["wrapped"] = self.wrapped
+
+        return data


### PR DESCRIPTION
The [OpenAPI Specification version 3.1.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#encoding-object) is the most recent and modern target for the `writableopenapi` script – mainly for interests within the [Nova](https://github.com/discordnova) organization.


This changes list implements the specification as a set of Python (data)classes, with methods to dump representations into JSON and YAML.